### PR TITLE
fix: CodeCell.props.text does not support element type

### DIFF
--- a/src/Hunk/CodeCell.js
+++ b/src/Hunk/CodeCell.js
@@ -43,7 +43,7 @@ const CodeCell = props => {
 };
 
 CodeCell.propTypes = {
-    text: PropTypes.string.isRequired,
+    text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     tokens: PropTypes.arrayOf(PropTypes.object),
 };
 


### PR DESCRIPTION
From the content of the README.md document, it seems that it is more complex to enable code highlight in `react-diff-view`, so I decided to use the HTML code returned by the back end that has been highlighted.

This code fragment shows how I render HTML code:

```js
result.hunks = convertDiffHunks(result.text).map((hunk) => ({
  ...hunk,
  changes: hunk.changes.map((change) => ({
    ...change,
    content: <div className='highlight' dangerouslySetInnerHTML={{ __html: change.content }} />
  }))
}));
```

However, in development mode, the console will have the following warning:

![image](https://user-images.githubusercontent.com/1730073/103984382-fcfe6300-51c1-11eb-8299-116dfa7f64de.png)

This PR adds element type support to the `CodeCell.props.text` to handle this warning message.

Maybe this is not the optimal solution. Is there a better way to deal with it?