### PR TITLE
build: fix errors when running the postcss and sed commands

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,5 @@ yarn
 yarn clean
 export NODE_ENV=production
 node rollup.js
-postcss -o style/index.css src/styles/index.css
-sed -i '' 's/}/;}/g' style/index.css
+node node_modules/.bin/postcss -o style/index.css src/styles/index.css
+sed -i 's/}/;}/g' style/index.css


### PR DESCRIPTION
Fixed these errors:

```
scripts/build.sh: 5: scripts/build.sh: postcss: not found
sed: can't read  s/}/;}/g: No such file or directory
```
