### PR TITLE
Stop adding all the styles of the cell to the anchor.

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -42,8 +42,7 @@
     display: block;
 }
 
-.diff-gutter,
-.diff-gutter > a {
+.diff-gutter {
     padding: 0 1ch;
     text-align: right;
     cursor: pointer;


### PR DESCRIPTION
The padding will stack up meaning you get line breaks in the anchor. The other attributes look like they're unnecessary, the anchor should inherit them anyway.

Fixes otakustay/react-diff-view#131