### PR TITLE
Remove recompose as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "diff-match-patch": "^1.0.5",
-    "recompose": "^0.30.0",
     "shallow-equal": "^1.2.1",
     "warning": "^4.0.2"
   },

--- a/src/hocs/minCollapsedLines.js
+++ b/src/hocs/minCollapsedLines.js
@@ -1,4 +1,4 @@
-import {wrapDisplayName} from 'recompose';
+import {wrapDisplayName} from './wrapDisplayName';
 import {useMinCollapsedLines} from '../hooks';
 
 export default minLinesExclusive => ComponentIn => {

--- a/src/hocs/withChangeSelect.js
+++ b/src/hocs/withChangeSelect.js
@@ -1,4 +1,4 @@
-import {wrapDisplayName} from 'recompose';
+import {wrapDisplayName} from './wrapDisplayName';
 import {useChangeSelect} from '../hooks';
 
 export default options => ComponentIn => {

--- a/src/hocs/withSourceExpansion.js
+++ b/src/hocs/withSourceExpansion.js
@@ -1,4 +1,4 @@
-import {wrapDisplayName} from 'recompose';
+import {wrapDisplayName} from './wrapDisplayName';
 import {useSourceExpansion} from '../hooks';
 
 export default () => ComponentIn => {

--- a/src/hocs/withTokenizeWorker.js
+++ b/src/hocs/withTokenizeWorker.js
@@ -1,4 +1,4 @@
-import {wrapDisplayName} from 'recompose';
+import {wrapDisplayName} from './wrapDisplayName';
 import {useTokenizeWorker} from '../hooks';
 
 const defaultMapPayload = data => {

--- a/src/hocs/wrapDisplayName.js
+++ b/src/hocs/wrapDisplayName.js
@@ -1,0 +1,9 @@
+// Based on https://github.com/acdlite/recompose/blob/a255b23/src/packages/recompose/getDisplayName.js
+const getDisplayName = Component => {
+    return (typeof Component === 'string' || Component == null)
+        ? Component
+        : Component.displayName || Component.name || 'Component';
+};
+
+// based on https://github.com/acdlite/recompose/blob/d55575f/src/packages/recompose/wrapDisplayName.js
+export const wrapDisplayName = (BaseComponent, hocName) => `${hocName}(${getDisplayName(BaseComponent)})`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,11 +2919,6 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-change-emitter@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.npm.taobao.org/change-emitter/download/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
-  integrity sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=
-
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npm.taobao.org/char-regex/download/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -4849,7 +4844,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.npm.taobao.org/fbjs/download/fbjs-0.8.17.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffbjs%2Fdownload%2Ffbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -9562,18 +9557,6 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
-recompose@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.npm.taobao.org/recompose/download/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
-  integrity sha1-gnc2QbOSfox9JKDYfWWu66GKq9A=
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
-    symbol-observable "^1.0.4"
-
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npm.taobao.org/reflect.ownkeys/download/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
@@ -10888,11 +10871,6 @@ svgo@^1.0.0:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-symbol-observable@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.npm.taobao.org/symbol-observable/download/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
When installing `react-diff-view` I was getting 


> npm WARN deprecated core-js@1.2.7: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.


So I ran 

```
$ npm ls core-js
app@0.0.1
└─┬ react-diff-view@2.4.9
  └─┬ recompose@0.30.0
    └─┬ fbjs@0.8.18
      └── core-js@1.2.7
```

And I figured I could see if I could fix this dependency. So from what I could tell, it was only the `wrapDisplayName()` utility that was being used. And while I realize that the core-js polyfill issue is probably not affecting `react-diff-view`, it still seems like an unnecessary dependency. So I created a copy of that method and used that, allowing to remove `recompose` as a dependency.