### PR TITLE
fix: export types used in props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {useChangeSelect, useMinCollapsedLines, useSourceExpansion, useTokenizeWo
 export type {DiffProps, DiffType} from './Diff';
 export type {HunkProps} from './Hunk';
 export type {DecorationProps} from './Decoration';
+export type {EventMap, HunkTokens, GutterType, ViewType, RenderToken, RenderGutter} from './context'
 export type {ChangeData, FileData, HunkData, ParseOptions, Source} from './utils';
 export type {Pair, RangeTokenNode, TextNode, TokenNode, TokenPath, TokenizeEnhancer, TokenizeOptions} from './tokenize';
 export type {


### PR DESCRIPTION
Hello! I managed to upgrade to use the packaged types without much issue in my repo (https://github.com/oBusk/npm-diff.app/commit/784989d14a664b871b2fd3552e9660f1f763948c). The one thing I ran into was that the Types that are used in `DiffProps` is not exported meaning that a consumer cannot declare a variable that is later going to be passed to `react-diff-view`

```typescript
const viewType: ViewType = 'unified';

return () => <Diff viewType={viewType} />
```

So I went ahead and exported the specific type I needed, and also looked at all other Types that are used in the Props of the exported components but were not themselves exported.