### PR TITLE
remove inline-block style of markEdit area, which will prevent us from search continuous content

### DIFF
--- a/site/components/DiffView/diff.global.less
+++ b/site/components/DiffView/diff.global.less
@@ -83,7 +83,6 @@
 }
 
 .diff-code-edit {
-    display: inline-block;
     color: inherit;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -86,7 +86,6 @@
 }
 
 .diff-code-edit {
-    display: inline-block;
     color: inherit;
 }
 


### PR DESCRIPTION
react-diff-view use `.diff-code-edit` with `display: inline-block` to wrap the markEdit area, inline-block will break the continuous text, which will stop us from search the continuous text:

![image](https://user-images.githubusercontent.com/13199771/236806354-bef6e058-06cb-4d17-a70f-39fa4a0c9077.png)


