### PR TITLE
feat: support custom line className with generateLineClassName

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Here is the full list of its props:
 - `{boolean} optimizeSelection`: Whether to optimize selection to a single column, when this prop is set to `true` in split mode, user can only select code from either old or new side, this can help copy and paste lines of code. This feature can cause some performance dropdown when the diff is extremely large, so it is turned off by default.
 - `{Function} renderToken`: A function to render customized syntax tokens, see [Pick ranges](#pick-ranges) section for detail.
 - `{Function} renderGutter`: A function to render content in gutter cells, see [Customize gutter](#customize-gutter) section for detail.
+- `{Function} generateLineClassName`: A function to provide extra classNames for specific lines.
 
 #### Key of change
 

--- a/src/Diff/index.tsx
+++ b/src/Diff/index.tsx
@@ -22,6 +22,9 @@ export interface DiffProps {
     viewType?: ViewType;
     gutterType?: GutterType;
     generateAnchorID?: (change: ChangeData) => string | undefined;
+    generateLineClassName?: (
+        lineChange: [ChangeData | null, ChangeData | null] | ChangeData | null
+    ) => string | undefined;
     selectedChanges?: string[];
     widgets?: Record<string, ReactNode>;
     optimizeSelection?: boolean;
@@ -77,6 +80,7 @@ function Diff(props: DiffProps) {
         gutterEvents = DEFAULT_CONTEXT_VALUE.gutterEvents,
         codeEvents = DEFAULT_CONTEXT_VALUE.codeEvents,
         generateAnchorID = DEFAULT_CONTEXT_VALUE.generateAnchorID,
+        generateLineClassName = DEFAULT_CONTEXT_VALUE.generateLineClassName,
         selectedChanges = DEFAULT_CONTEXT_VALUE.selectedChanges,
         widgets = DEFAULT_CONTEXT_VALUE.widgets,
         renderGutter = DEFAULT_CONTEXT_VALUE.renderGutter,
@@ -167,6 +171,7 @@ function Diff(props: DiffProps) {
                 codeEvents,
                 gutterEvents,
                 generateAnchorID,
+                generateLineClassName,
                 selectedChanges,
                 widgets,
                 renderGutter,
@@ -178,6 +183,7 @@ function Diff(props: DiffProps) {
             codeClassName,
             codeEvents,
             generateAnchorID,
+            generateLineClassName,
             gutterClassName,
             gutterEvents,
             gutterType,

--- a/src/Hunk/SplitHunk/SplitChange.tsx
+++ b/src/Hunk/SplitHunk/SplitChange.tsx
@@ -153,6 +153,7 @@ function SplitChange(props: SplitChangeProps) {
         codeEvents,
         hideGutter,
         generateAnchorID,
+        generateLineClassName,
         gutterAnchor,
         renderToken,
         renderGutter,
@@ -165,6 +166,7 @@ function SplitChange(props: SplitChangeProps) {
     const newCodeEvents = useCallbackOnSide('new', setHover, newChange, codeEvents);
     const oldAnchorID = oldChange && generateAnchorID(oldChange);
     const newAnchorID = newChange && generateAnchorID(newChange);
+    const customLineClassName = generateLineClassName([oldChange, newChange]);
     const commons = {
         monotonous,
         hideGutter,
@@ -204,7 +206,7 @@ function SplitChange(props: SplitChangeProps) {
 
     if (monotonous) {
         return (
-            <tr className={classNames('diff-line', className)}>
+            <tr className={classNames('diff-line', className, customLineClassName)}>
                 {renderCells(oldChange ? oldArgs : newArgs)}
             </tr>
         );
@@ -227,7 +229,7 @@ function SplitChange(props: SplitChangeProps) {
     })(oldChange, newChange);
 
     return (
-        <tr className={classNames('diff-line', lineTypeClassName, className)}>
+        <tr className={classNames('diff-line', lineTypeClassName, className, customLineClassName)}>
             {renderCells(oldArgs)}
             {renderCells(newArgs)}
         </tr>

--- a/src/Hunk/UnifiedHunk/UnifiedChange.tsx
+++ b/src/Hunk/UnifiedHunk/UnifiedChange.tsx
@@ -73,6 +73,7 @@ function UnifiedChange(props: UnifiedChangeProps) {
         hideGutter,
         gutterAnchor,
         generateAnchorID,
+        generateLineClassName,
         renderToken,
         renderGutter,
     } = props;
@@ -84,6 +85,7 @@ function UnifiedChange(props: UnifiedChangeProps) {
     const boundCodeEvents = useBoundCallbacks(codeEvents, eventArg, hoverOn, hoverOff);
 
     const anchorID = generateAnchorID(change);
+    const customLineClassName = generateLineClassName(change);
     const gutterClassNameValue = classNames(
         'diff-gutter',
         `diff-gutter-${type}`,
@@ -98,7 +100,7 @@ function UnifiedChange(props: UnifiedChangeProps) {
     );
 
     return (
-        <tr id={anchorID} className={classNames('diff-line', className)}>
+        <tr id={anchorID} className={classNames('diff-line', className, customLineClassName)}>
             {
                 !hideGutter && renderGutterCell(
                     gutterClassNameValue,

--- a/src/Hunk/interface.ts
+++ b/src/Hunk/interface.ts
@@ -8,6 +8,9 @@ export interface SharedProps {
     gutterAnchor: boolean;
     monotonous: boolean;
     generateAnchorID: (change: ChangeData) => string | undefined;
+    generateLineClassName: (
+        lineChange: [ChangeData | null, ChangeData | null] | ChangeData | null
+    ) => string | undefined;
     renderToken?: RenderToken;
     renderGutter: RenderGutter;
 }

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -54,6 +54,13 @@ export interface ContextProps {
     selectedChanges: string[];
     tokens?: HunkTokens | null;
     generateAnchorID: (change: ChangeData) => string | undefined;
+    /**
+     * provide extra className for specific lines
+     * <[oldChange, newChange]> for split diff mode and <changeData> for unified diff mode
+     */
+    generateLineClassName: (
+        lineChange: [ChangeData | null, ChangeData | null] | ChangeData | null
+    ) => string | undefined;
     renderToken?: RenderToken;
     renderGutter: RenderGutter;
     gutterEvents: EventMap;
@@ -72,6 +79,7 @@ export const DEFAULT_CONTEXT_VALUE: ContextProps = {
     hideGutter: false,
     selectedChanges: [],
     generateAnchorID: () => undefined,
+    generateLineClassName: () => undefined,
     renderGutter: ({renderDefault, wrapInAnchor}) => wrapInAnchor(renderDefault()),
     codeEvents: {},
     gutterEvents: {},


### PR DESCRIPTION
User Case: to mark expanded lines with different background like github, and the expanded information is stored outside this component
![image](https://github.com/otakustay/react-diff-view/assets/13199771/83cfea09-0520-4942-9fe3-6fa56b399d0d)
