### PR TITLE
fix: not showing empty context line below diff

### DIFF
--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -94,7 +94,7 @@ function normalizeDiffText(text: string) {
 }
 
 export function parseDiff(text: string, options: ParseOptions = {}): File[] {
-    const diffText = normalizeDiffText(text.trim());
+    const diffText = normalizeDiffText(text.trimStart());
     const files = parser.parse(diffText);
 
     return files.map(file => mapFile(file, options));


### PR DESCRIPTION
As described in issue #214 if there was an empty context line below diff the empty line was not shown, this PR tries to fix it.

Before fix:
![image](https://github.com/otakustay/react-diff-view/assets/80856731/d0229c99-bd43-41c4-a623-9a921bfc5adc)


After fix:
![image](https://github.com/otakustay/react-diff-view/assets/80856731/8c5429cc-602a-4ff5-a095-bb9e6fad7c82)
